### PR TITLE
Pick the nearest element in the direction of scrolling

### DIFF
--- a/src/scrollsnap-polyfill.js
+++ b/src/scrollsnap-polyfill.js
@@ -320,8 +320,8 @@
       // check if object snappoint is "close" enough to scrollable snappoint
 
       // not scrolled past element snap coords
-      if ((left <= snapCoords.x && left + getWidth(scrollObj) >= snapCoords.x &&
-           top <= snapCoords.y && top + getHeight(scrollObj) >= snapCoords.y)) {
+      if ((left*primaryDirection <= snapCoords.x*primaryDirection &&
+           top*primaryDirection <= snapCoords.y*primaryDirection)) {
         // ok, we found a snap point.
         currentIteration = i;
         // stay in bounds (minimum: 0, maxmimum: absolute height)


### PR DESCRIPTION
I think this behaviour is best generally. When compared to Firefox's implementation, Firefox will always scroll to the next in the direction if you press a button on the scrollbar, but if you drag it will snap to the current nearest. In our case, we can't tell which happened, so I think going to the nearest in the direction of scrolling is a reasonable option.
