### PR TITLE
Added support for decimal numbers in scroll-snap-destination. 

### DIFF
--- a/src/scrollsnap-polyfill.js
+++ b/src/scrollsnap-polyfill.js
@@ -438,7 +438,7 @@
    */
   function parseSnapCoordValue(declaration) {
     // regex to parse lengths
-    var regex = /(\d+)(px|%) (\d+)(px|%)/g,
+    var regex = /(\d+(?:\.\d*)?)(px|%) (\d+(?:\.\d*))(px|%)/g,
         // defaults
         parsed = {y: {value: 0, unit: 'px'},
                   x: {value: 0, unit: 'px'}},


### PR DESCRIPTION
Trailing dots are allowed, leading dots aren't.

Thank you for merging this! :)